### PR TITLE
markWinningBidAsUsed functionality

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -595,6 +595,18 @@ $$PREBID_GLOBAL$$.getHighestCpmBids = function (adUnitCode) {
 };
 
 /**
+ * Mark the winning video bid as used
+ * @param {string} adUnitCode - required ad unit code
+ * @alias module:pbjs.markWinningVideoBidAsUsed
+ */
+$$PREBID_GLOBAL$$.markWinningVideoBidAsUsed = function (adUnitCode) {
+  const bids = targeting.getWinningBids(adUnitCode);
+  if (bids.length > 0) {
+    bids[0].status = RENDERED;
+  }
+};
+
+/**
  * Get Prebid config options
  * @param {Object} options
  * @alias module:pbjs.getConfig

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -606,7 +606,7 @@ $$PREBID_GLOBAL$$.getHighestCpmBids = function (adUnitCode) {
 /**
  * Mark the winning bid as used, should only be used in conjunction with video
  * @param {string} adUnitCode - required ad unit code
- * @alias module:pbjs.markWinningVideoBidAsUsed
+ * @alias module:pbjs.markWinningBidAsUsed
  */
 $$PREBID_GLOBAL$$.markWinningBidAsUsed = function (adUnitCode) {
   const bids = targeting.getWinningBids(adUnitCode);

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -604,11 +604,11 @@ $$PREBID_GLOBAL$$.getHighestCpmBids = function (adUnitCode) {
 };
 
 /**
- * Mark the winning video bid as used
+ * Mark the winning bid as used, should only be used in conjunction with video
  * @param {string} adUnitCode - required ad unit code
  * @alias module:pbjs.markWinningVideoBidAsUsed
  */
-$$PREBID_GLOBAL$$.markWinningVideoBidAsUsed = function (adUnitCode) {
+$$PREBID_GLOBAL$$.markWinningBidAsUsed = function (adUnitCode) {
   const bids = targeting.getWinningBids(adUnitCode);
   if (bids.length > 0) {
     bids[0].status = RENDERED;

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -9,7 +9,7 @@ import {
   createBidReceived
 } from 'test/fixtures/fixtures';
 import { auctionManager, newAuctionManager } from 'src/auctionManager';
-import { targeting, newTargeting } from 'src/targeting';
+import { targeting, newTargeting, RENDERED } from 'src/targeting';
 import { config as configObj } from 'src/config';
 import * as ajaxLib from 'src/ajax';
 import * as auctionModule from 'src/auction';
@@ -1825,6 +1825,25 @@ describe('Unit: Prebid Module', function () {
 
       const highestCpmBids = $$PREBID_GLOBAL$$.getHighestCpmBids('/19968336/header-bid-tag-0');
       expect(highestCpmBids.length).to.equal(0);
+      resetAuction();
+    });
+  });
+
+  describe('markWinningBidAsUsed', () => {
+    it('marks the winning bid object as used for the given adUnitCode', () => {
+      // make sure the auction has "state" and does not reload the fixtures
+      const adUnitCode = '/19968336/header-bid-tag-0';
+      const bidsReceived = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode);
+      auction.getBidsReceived = function() { return bidsReceived.bids };
+
+      // mark the bid and verify the state has changed to RENDERED
+      const winningBid = targeting.getWinningBids(adUnitCode)[0];
+      $$PREBID_GLOBAL$$.markWinningBidAsUsed(adUnitCode);
+      const markedBid = $$PREBID_GLOBAL$$.getBidResponsesForAdUnitCode(adUnitCode)
+        .bids
+        .find(bid => bid.adId === winningBid.adId);
+
+      expect(markedBid.status).to.equal(RENDERED);
       resetAuction();
     });
   });


### PR DESCRIPTION
Added markWinningBidAsUsed to mark a bid as used. Useful in conjunction with video, cause that’s not marked as “used” automatically.